### PR TITLE
Traverse directories

### DIFF
--- a/config.go
+++ b/config.go
@@ -1,9 +1,7 @@
 package main
 
 import (
-	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"time"
@@ -18,6 +16,7 @@ type FileList struct {
 type DirectoryConf struct {
 	Directory string
 	Git       bool
+	Depth     int
 }
 
 type FoundDirectories struct {
@@ -26,15 +25,17 @@ type FoundDirectories struct {
 
 type Directories struct {
 	name     string
+	depth    int
 	searched bool
 	time     time.Time
 	child    []Directories
 }
 
-func (f *FileList) addDirectory(d string, git bool) {
+func (f *FileList) addDirectory(d string, git bool, depth int) {
 	newDirectory := DirectoryConf{
 		Directory: d,
 		Git:       git,
+		Depth:     depth,
 	}
 	_, found := findInDirectoryConf(f.Directories, d)
 	if !found {
@@ -53,7 +54,7 @@ func (f *FileList) removeDirectory(directory string) {
 
 func (f *FileList) createBaseConfig(filename string) {
 
-	(*f).addDirectory(getCwd(), false)
+	(*f).addDirectory(getCwd(), false, 0)
 
 	errMkdir := os.MkdirAll(filepath.Dir(filename), 0755)
 	if errMkdir != nil {
@@ -62,41 +63,4 @@ func (f *FileList) createBaseConfig(filename string) {
 	}
 
 	f.saveConfigToFile(filename)
-}
-
-func (f *FileList) saveConfigToFile(filename string) error {
-	bs, err := json.MarshalIndent(*f, "", "  ")
-	if err != nil {
-		fmt.Println("Error:", err)
-		os.Exit(1)
-	}
-	return ioutil.WriteFile(filename, bs, 0644)
-}
-
-func readConfigFromFile(filename string) FileList {
-	var filelist FileList
-
-	if _, err := os.Stat(filename); err == nil {
-		bs, err := ioutil.ReadFile(filename)
-		if err != nil {
-			fmt.Println("Error:", err)
-			os.Exit(1)
-		}
-
-		jsonErr := json.Unmarshal(bs, &filelist)
-		if jsonErr != nil {
-			fmt.Println("Error:", jsonErr)
-			os.Exit(1)
-		}
-		return filelist
-	} else if os.IsNotExist(err) {
-		filelist.createBaseConfig(filename)
-		fmt.Printf("Creating configuration at:\n   %v\n", filename)
-		fmt.Println("Configuration created. Re-run command to search")
-		os.Exit(0)
-	} else {
-		fmt.Println("Error: Most likely .config/quickswitch is a file not a dir")
-	}
-
-	return filelist
 }

--- a/config.go
+++ b/config.go
@@ -6,11 +6,13 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
+	"sync"
 )
 
 // FileList Holds the directories to search
 type FileList struct {
 	Directories []DirectoryConf
+	sync.Mutex
 }
 
 // DirectoryConf Holds configuration for each directory
@@ -24,7 +26,10 @@ func (f *FileList) addDirectory(d string, git bool) {
 		Directory: d,
 		Git:       git,
 	}
-	f.Directories = append(f.Directories, newDirectory)
+	_, found := findInDirectoryConf(f.Directories, d)
+	if !found {
+		f.Directories = append(f.Directories, newDirectory)
+	}
 }
 
 func (f *FileList) removeDirectory(directory string) {

--- a/config.go
+++ b/config.go
@@ -18,11 +18,12 @@ func (f *FileList) addDirectory(directory string) {
 }
 
 func (f *FileList) removeDirectory(directory string) {
-	for i, v := range f.Directories {
-		if v == directory {
-			f.Directories = append(f.Directories[:i], f.Directories[i+1:]...)
-		}
+	i, found := findInSlice(f.Directories, directory)
+	if !found {
+		fmt.Println("Directory not found in config. Make sure you're using the exact path")
+		os.Exit(1)
 	}
+	f.Directories = append(f.Directories[:i], f.Directories[i+1:]...)
 }
 
 func (f *FileList) createBaseConfig(filename string) {

--- a/config.go
+++ b/config.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"path/filepath"
 	"sync"
+	"time"
 )
 
 // FileList Holds the directories to search
@@ -26,8 +27,10 @@ type FoundDirectories struct {
 }
 
 type Directories struct {
-	name  string
-	child []Directories
+	name     string
+	searched bool
+	time     time.Time
+	child    []Directories
 }
 
 func (f *FileList) addDirectory(d string, git bool) {

--- a/config.go
+++ b/config.go
@@ -8,17 +8,27 @@ import (
 	"path/filepath"
 )
 
-// FileList Holds the configure paths to search
+// FileList Holds the directories to search
 type FileList struct {
-	Directories []string
+	Directories []DirectoryConf
 }
 
-func (f *FileList) addDirectory(directory string) {
-	f.Directories = append(f.Directories, directory)
+// DirectoryConf Holds configuration for each directory
+type DirectoryConf struct {
+	Directory string
+	Git       bool
+}
+
+func (f *FileList) addDirectory(d string, git bool) {
+	newDirectory := DirectoryConf{
+		Directory: d,
+		Git:       git,
+	}
+	f.Directories = append(f.Directories, newDirectory)
 }
 
 func (f *FileList) removeDirectory(directory string) {
-	i, found := findInSlice(f.Directories, directory)
+	i, found := findInDirectoryConf(f.Directories, directory)
 	if !found {
 		fmt.Println("Directory not found in config. Make sure you're using the exact path")
 		os.Exit(1)
@@ -28,7 +38,7 @@ func (f *FileList) removeDirectory(directory string) {
 
 func (f *FileList) createBaseConfig(filename string) {
 
-	(*f).addDirectory(getCwd())
+	(*f).addDirectory(getCwd(), false)
 
 	errMkdir := os.MkdirAll(filepath.Dir(filename), 0755)
 	if errMkdir != nil {

--- a/config.go
+++ b/config.go
@@ -6,14 +6,11 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
-	"sync"
-	"time"
 )
 
 // FileList Holds the directories to search
 type FileList struct {
 	Directories []DirectoryConf
-	sync.Mutex
 }
 
 // DirectoryConf Holds configuration for each directory
@@ -29,7 +26,7 @@ type FoundDirectories struct {
 type Directories struct {
 	name     string
 	searched bool
-	time     time.Time
+	time     int64
 	child    []Directories
 }
 

--- a/config.go
+++ b/config.go
@@ -6,6 +6,7 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
+	"time"
 )
 
 // FileList Holds the directories to search
@@ -26,7 +27,7 @@ type FoundDirectories struct {
 type Directories struct {
 	name     string
 	searched bool
-	time     int64
+	time     time.Time
 	child    []Directories
 }
 

--- a/config.go
+++ b/config.go
@@ -21,6 +21,15 @@ type DirectoryConf struct {
 	Git       bool
 }
 
+type FoundDirectories struct {
+	directories []string
+}
+
+type Directories struct {
+	name  string
+	child []Directories
+}
+
 func (f *FileList) addDirectory(d string, git bool) {
 	newDirectory := DirectoryConf{
 		Directory: d,

--- a/fuzzy.go
+++ b/fuzzy.go
@@ -4,12 +4,12 @@ import (
 	"github.com/ktr0731/go-fuzzyfinder"
 )
 
-func (f FileList) getDirectory(cwd string) string {
-	idx, err := fuzzyfinder.Find(f.Directories, func(i int) string {
-		return f.Directories[i].Directory
+func (f FoundDirectories) getDirectory(cwd string) string {
+	idx, err := fuzzyfinder.Find(f.directories, func(i int) string {
+		return f.directories[i]
 	})
 	if err != nil {
 		return cwd
 	}
-	return f.Directories[idx].Directory
+	return f.directories[idx]
 }

--- a/fuzzy.go
+++ b/fuzzy.go
@@ -4,12 +4,17 @@ import (
 	"github.com/ktr0731/go-fuzzyfinder"
 )
 
-func (f FoundDirectories) getDirectory(cwd string) string {
-	idx, err := fuzzyfinder.Find(f.directories, func(i int) string {
-		return f.directories[i]
+func getDirectory(m map[string]int64, cwd string) string {
+	var list []string
+
+	for i := range m {
+		list = append(list, i)
+	}
+	idx, err := fuzzyfinder.Find(list, func(i int) string {
+		return list[i]
 	})
 	if err != nil {
 		return cwd
 	}
-	return f.directories[idx]
+	return list[idx]
 }

--- a/fuzzy.go
+++ b/fuzzy.go
@@ -1,10 +1,12 @@
 package main
 
 import (
+	"time"
+
 	"github.com/ktr0731/go-fuzzyfinder"
 )
 
-func getDirectory(m map[string]int64, cwd string) string {
+func getDirectory(m map[string]time.Time, cwd string) string {
 	var list []string
 
 	for i := range m {

--- a/fuzzy.go
+++ b/fuzzy.go
@@ -6,10 +6,10 @@ import (
 
 func (f FileList) getDirectory(cwd string) string {
 	idx, err := fuzzyfinder.Find(f.Directories, func(i int) string {
-		return f.Directories[i]
+		return f.Directories[i].Directory
 	})
 	if err != nil {
 		return cwd
 	}
-	return f.Directories[idx]
+	return f.Directories[idx].Directory
 }

--- a/helpers.go
+++ b/helpers.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"sync"
 )
 
@@ -35,35 +36,12 @@ func findInSlice(slice []string, val string) (int, bool) {
 	return -1, false
 }
 
-func isGitDirectory(d string) bool {
-	//fmt.Println(d)
-	info, _ := os.Stat(d)
-	if info.IsDir() {
-		file, err := os.Open(d)
-		if err != nil {
-			fmt.Println("Error:", err)
-		}
-
-		names, err := file.Readdirnames(0)
-		if err != nil {
-			fmt.Println("Error:", err)
-		}
-
-		_, found := findInSlice(names, ".git")
-		if !found {
-			return false
-		}
-		return true
-	}
-
-	return false
-}
-
 func walkDir(dir string, d *FileList) {
 	defer wg.Done()
 
 	walk := func(path string, f os.FileInfo, err error) error {
-		if f.IsDir() && isGitDirectory(path) {
+		suffix := ".git"
+		if f.IsDir() && strings.HasSuffix(path, suffix) {
 			(*d).Lock()
 			(*d).addDirectory(path, false)
 			(*d).Unlock()
@@ -96,74 +74,6 @@ func walk(f FileList, d *FileList) FileList {
 	}
 	wg.Wait()
 	return (*d)
-}
-
-func walkDirectories2(f FileList, s int, e int) FileList {
-	var foundDir FileList
-
-	for s < e {
-		s++
-		for _, dir := range f.Directories {
-			info, _ := os.Stat(dir.Directory)
-			if info.IsDir() && isGitDirectory(dir.Directory) {
-				foundDir.addDirectory(dir.Directory, false)
-			} else if info.IsDir() {
-				file, err := os.Open(dir.Directory)
-				if err != nil {
-					fmt.Println("Error:", err)
-				}
-				names, err := file.Readdirnames(0)
-				if err != nil {
-					fmt.Println("Error:", err)
-				}
-				for _, v := range names {
-					var recurseDir FileList
-					recurseDir.addDirectory(filepath.Join(dir.Directory, v), false)
-					found := walkDirectories2(recurseDir, 0, 1)
-					for _, dir := range found.Directories {
-						foundDir.addDirectory(dir.Directory, false)
-					}
-				}
-			}
-		}
-	}
-	return foundDir
-}
-
-func walkDirectories(f *FileList) FileList {
-
-	var foundDir FileList
-
-	for _, dir := range f.Directories {
-		foundDir.addDirectory(dir.Directory, false)
-		if isGitDirectory(dir.Directory) {
-			continue
-		}
-		file, err := os.Open(dir.Directory)
-		if err != nil {
-			fmt.Println("Error:", err)
-		}
-
-		names, err := file.Readdirnames(0)
-		if err != nil {
-			fmt.Println("Error:", err)
-		}
-
-		for _, v := range names {
-			var mergeDir FileList
-			mergeDir.addDirectory(filepath.Join(dir.Directory, v), false)
-			info, _ := os.Stat(filepath.Join(dir.Directory, v))
-			if info.IsDir() && isGitDirectory(filepath.Join(dir.Directory, v)) {
-				foundDir.addDirectory(filepath.Join(dir.Directory, v), false)
-			} else if info.IsDir() {
-				subDir := walkDirectories(&mergeDir)
-				for _, d := range subDir.Directories {
-					foundDir.addDirectory(d.Directory, false)
-				}
-			}
-		}
-	}
-	return foundDir
 }
 
 func getCwd() string {

--- a/helpers.go
+++ b/helpers.go
@@ -36,13 +36,13 @@ func findInSlice(slice []string, val string) (int, bool) {
 	return -1, false
 }
 
-func walkDir(p string, d Directories, f *map[string]time.Time, depth int, max_depth int) Directories {
+func walkDir(p string, d Directories, f *map[string]time.Time, depth int, maxDepth int) Directories {
 
 	d.name = p
 	d.depth = depth
 	var childdir []Directories
 
-	if d.depth < max_depth {
+	if d.depth < maxDepth {
 		file, err := os.Open(p)
 		if err != nil {
 			return d
@@ -61,7 +61,7 @@ func walkDir(p string, d Directories, f *map[string]time.Time, depth int, max_de
 
 				var newChild Directories
 
-				childdir = append(childdir, walkDir(childPath, newChild, f, d.depth+1, max_depth))
+				childdir = append(childdir, walkDir(childPath, newChild, f, d.depth+1, maxDepth))
 			}
 		}
 	}

--- a/helpers.go
+++ b/helpers.go
@@ -14,8 +14,39 @@ func getConfigFile(f string) string {
 	return filepath.Join(home, f)
 }
 
-func walkDirectories(f *FileList) {
+func findInSlice(slice []string, val string) (int, bool) {
+	for i, item := range slice {
+		if item == val {
+			return i, true
+		}
+	}
+	return -1, false
+}
+
+func isGitDirectory(d string) bool {
+	file, err := os.Open(d)
+	if err != nil {
+		fmt.Println("Error:", err)
+	}
+
+	names, err := file.Readdirnames(0)
+	if err != nil {
+		fmt.Println("Error:", err)
+	}
+
+	_, found := findInSlice(names, ".git")
+	if !found {
+		return false
+	}
+
+	return true
+}
+
+func walkDirectories(f *FileList) FileList {
+	var foundDir FileList
+
 	for _, dir := range f.Directories {
+		foundDir.addDirectory(dir)
 		file, err := os.Open(dir)
 		if err != nil {
 			fmt.Println("Error:", err)
@@ -28,11 +59,12 @@ func walkDirectories(f *FileList) {
 
 		for _, v := range names {
 			info, _ := os.Stat(filepath.Join(dir, v))
-			if info.IsDir() {
-				f.addDirectory(filepath.Join(dir, v))
+			if info.IsDir() && isGitDirectory(filepath.Join(dir, v)) {
+				foundDir.addDirectory(filepath.Join(dir, v))
 			}
 		}
 	}
+	return foundDir
 }
 
 func getCwd() string {

--- a/helpers.go
+++ b/helpers.go
@@ -43,7 +43,7 @@ func walkDir(dir string, d *FileList) {
 		suffix := ".git"
 		if f.IsDir() && strings.HasSuffix(path, suffix) {
 			(*d).Lock()
-			(*d).addDirectory(path, false)
+			(*d).addDirectory(strings.TrimSuffix(path, suffix), false)
 			(*d).Unlock()
 		} else if f.IsDir() && path != dir {
 			file, err := os.Open(path)

--- a/helpers.go
+++ b/helpers.go
@@ -56,6 +56,9 @@ func walkDirectories(f *FileList) FileList {
 
 	for _, dir := range f.Directories {
 		foundDir.addDirectory(dir.Directory, false)
+		if isGitDirectory(dir.Directory) {
+			continue
+		}
 		file, err := os.Open(dir.Directory)
 		if err != nil {
 			fmt.Println("Error:", err)
@@ -67,9 +70,16 @@ func walkDirectories(f *FileList) FileList {
 		}
 
 		for _, v := range names {
+			var mergeDir FileList
+			mergeDir.addDirectory(filepath.Join(dir.Directory, v), false)
 			info, _ := os.Stat(filepath.Join(dir.Directory, v))
 			if info.IsDir() && isGitDirectory(filepath.Join(dir.Directory, v)) {
 				foundDir.addDirectory(filepath.Join(dir.Directory, v), false)
+			} else if info.IsDir() {
+				subDir := walkDirectories(&mergeDir)
+				for _, d := range subDir.Directories {
+					foundDir.addDirectory(d.Directory, false)
+				}
 			}
 		}
 	}

--- a/helpers.go
+++ b/helpers.go
@@ -52,11 +52,17 @@ func walkDir(p string, d Directories, f *map[string]time.Time, depth int, max_de
 			return d
 		}
 		for _, v := range names {
-			childPath := p + "/" + v
+			info, err := os.Stat(p + "/" + v)
+			if err != nil {
+				return d
+			}
+			if info.IsDir() {
+				childPath := p + "/" + v
 
-			var newChild Directories
+				var newChild Directories
 
-			childdir = append(childdir, walkDir(childPath, newChild, f, d.depth+1, max_depth))
+				childdir = append(childdir, walkDir(childPath, newChild, f, d.depth+1, max_depth))
+			}
 		}
 	}
 	d.child = childdir

--- a/helpers.go
+++ b/helpers.go
@@ -36,7 +36,7 @@ func findInSlice(slice []string, val string) (int, bool) {
 	return -1, false
 }
 
-func walkDir(p string, d Directories, f *map[string]int64) Directories {
+func walkDir(p string, d Directories, f *map[string]time.Time) Directories {
 
 	d.name = p
 	var childdir []Directories
@@ -56,13 +56,13 @@ func walkDir(p string, d Directories, f *map[string]int64) Directories {
 		}
 		if v == ".git" {
 			d.searched = true
-			d.time = time.Now().Unix()
-			(*f)[p] = time.Now().Unix()
+			d.time = time.Now()
+			(*f)[p] = time.Now()
 			return d
 		} else if !info.IsDir() {
 			d.searched = true
-			d.time = time.Now().Unix()
-			(*f)[p] = time.Now().Unix()
+			d.time = time.Now()
+			(*f)[p] = time.Now()
 			return d
 		}
 	}
@@ -76,13 +76,13 @@ func walkDir(p string, d Directories, f *map[string]int64) Directories {
 	}
 	d.child = childdir
 	d.searched = true
-	d.time = time.Now().Unix()
-	(*f)[p] = time.Now().Unix()
+	d.time = time.Now()
+	(*f)[p] = time.Now()
 
 	return d
 }
 
-func walk(f FileList, flat map[string]int64) {
+func walk(f FileList, flat map[string]time.Time) {
 	var d Directories
 	d.name = "pseudo"
 	var childdir []Directories

--- a/helpers.go
+++ b/helpers.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"path/filepath"
 	"sync"
+	"time"
 )
 
 var wg sync.WaitGroup
@@ -68,6 +69,8 @@ func walkDir(p string, d Directories) Directories {
 
 	}
 	d.child = childdir
+	d.searched = true
+	d.time = time.Now()
 
 	return d
 }

--- a/helpers.go
+++ b/helpers.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"time"
 )
 
 func getConfigFile(f string) string {
@@ -58,7 +57,6 @@ func isGitDirectory(d string) bool {
 }
 
 func walkDirectories2(f FileList, s int, e int) FileList {
-	defer timeTrack(time.Now(), "walkDirectories2")
 	var foundDir FileList
 
 	for s < e {
@@ -91,7 +89,6 @@ func walkDirectories2(f FileList, s int, e int) FileList {
 }
 
 func walkDirectories(f *FileList) FileList {
-	defer timeTrack(time.Now(), "walkDirectories")
 
 	var foundDir FileList
 

--- a/helpers.go
+++ b/helpers.go
@@ -14,6 +14,15 @@ func getConfigFile(f string) string {
 	return filepath.Join(home, f)
 }
 
+func findInDirectoryConf(slice []DirectoryConf, val string) (int, bool) {
+	for i, item := range slice {
+		if item.Directory == val {
+			return i, true
+		}
+	}
+	return -1, false
+}
+
 func findInSlice(slice []string, val string) (int, bool) {
 	for i, item := range slice {
 		if item == val {
@@ -46,8 +55,8 @@ func walkDirectories(f *FileList) FileList {
 	var foundDir FileList
 
 	for _, dir := range f.Directories {
-		foundDir.addDirectory(dir)
-		file, err := os.Open(dir)
+		foundDir.addDirectory(dir.Directory, false)
+		file, err := os.Open(dir.Directory)
 		if err != nil {
 			fmt.Println("Error:", err)
 		}
@@ -58,9 +67,9 @@ func walkDirectories(f *FileList) FileList {
 		}
 
 		for _, v := range names {
-			info, _ := os.Stat(filepath.Join(dir, v))
-			if info.IsDir() && isGitDirectory(filepath.Join(dir, v)) {
-				foundDir.addDirectory(filepath.Join(dir, v))
+			info, _ := os.Stat(filepath.Join(dir.Directory, v))
+			if info.IsDir() && isGitDirectory(filepath.Join(dir.Directory, v)) {
+				foundDir.addDirectory(filepath.Join(dir.Directory, v), false)
 			}
 		}
 	}

--- a/io.go
+++ b/io.go
@@ -1,0 +1,46 @@
+package main
+
+import (
+	"encoding/gob"
+	"fmt"
+	"os"
+)
+
+func saveCacheToFile(m map[string]int64) {
+	file, err := os.Create(getConfigFile("quickswitch/cache.json"))
+	if err != nil {
+		fmt.Println("Error:", err)
+		os.Exit(1)
+	}
+
+	defer file.Close()
+
+	e := gob.NewEncoder(file)
+
+	err = e.Encode(m)
+	if err != nil {
+		fmt.Println("Error:", err)
+		os.Exit(1)
+	}
+	return
+}
+
+func readCacheFromFile() map[string]int64 {
+	cache := make(map[string]int64)
+
+	file, err := os.Open(getConfigFile("quickswitch/cache.json"))
+	if err != nil {
+		fmt.Println("Error:", err)
+		return cache
+	}
+	defer file.Close()
+
+	d := gob.NewDecoder(file)
+
+	err = d.Decode(&cache)
+	if err != nil {
+		fmt.Println("Error:", err)
+	}
+
+	return cache
+}

--- a/io.go
+++ b/io.go
@@ -2,10 +2,49 @@ package main
 
 import (
 	"encoding/gob"
+	"encoding/json"
 	"fmt"
+	"io/ioutil"
 	"os"
 	"time"
 )
+
+func (f *FileList) saveConfigToFile(filename string) error {
+	bs, err := json.MarshalIndent(*f, "", "  ")
+	if err != nil {
+		fmt.Println("Error:", err)
+		os.Exit(1)
+	}
+	return ioutil.WriteFile(filename, bs, 0644)
+}
+
+func readConfigFromFile(filename string) FileList {
+	var filelist FileList
+
+	if _, err := os.Stat(filename); err == nil {
+		bs, err := ioutil.ReadFile(filename)
+		if err != nil {
+			fmt.Println("Error:", err)
+			os.Exit(1)
+		}
+
+		jsonErr := json.Unmarshal(bs, &filelist)
+		if jsonErr != nil {
+			fmt.Println("Error:", jsonErr)
+			os.Exit(1)
+		}
+		return filelist
+	} else if os.IsNotExist(err) {
+		filelist.createBaseConfig(filename)
+		fmt.Printf("Creating configuration at:\n   %v\n", filename)
+		fmt.Println("Configuration created. Re-run command to search")
+		os.Exit(0)
+	} else {
+		fmt.Println("Error: Most likely .config/quickswitch is a file not a dir")
+	}
+
+	return filelist
+}
 
 func saveCacheToFile(m map[string]time.Time) {
 	file, err := os.Create(getConfigFile("quickswitch/cache.json"))

--- a/io.go
+++ b/io.go
@@ -4,9 +4,10 @@ import (
 	"encoding/gob"
 	"fmt"
 	"os"
+	"time"
 )
 
-func saveCacheToFile(m map[string]int64) {
+func saveCacheToFile(m map[string]time.Time) {
 	file, err := os.Create(getConfigFile("quickswitch/cache.json"))
 	if err != nil {
 		fmt.Println("Error:", err)
@@ -25,8 +26,8 @@ func saveCacheToFile(m map[string]int64) {
 	return
 }
 
-func readCacheFromFile() map[string]int64 {
-	cache := make(map[string]int64)
+func readCacheFromFile() map[string]time.Time {
+	cache := make(map[string]time.Time)
 
 	file, err := os.Open(getConfigFile("quickswitch/cache.json"))
 	if err != nil {

--- a/main.go
+++ b/main.go
@@ -7,7 +7,7 @@ import (
 )
 
 func main() {
-	configfile := getConfigFile("quickswitch/quickswitch.json")
+	configfile := getConfigFile("quickswitch/quickswitch2.json")
 
 	files := readConfigFromFile(configfile)
 

--- a/main.go
+++ b/main.go
@@ -47,7 +47,8 @@ func main() {
 		}
 	}
 
-	var foundDir FileList
-	walk(files, &foundDir)
-	fmt.Println(foundDir.getDirectory(getCwd()))
+	foundDirs := walk(files)
+	var found FoundDirectories
+	found.flattenDirectories(foundDirs)
+	fmt.Println(found.getDirectory(getCwd()))
 }

--- a/main.go
+++ b/main.go
@@ -12,7 +12,6 @@ func main() {
 	files := readConfigFromFile(configfile)
 
 	addCmd := flag.NewFlagSet("add", flag.ExitOnError)
-	//addFile := addCmd.String("path", "", "Full path to add")
 	addGit := addCmd.Bool("git", false, "Should recursive search for git repo be enables")
 	removeCmd := flag.NewFlagSet("remove", flag.ExitOnError)
 	flag.Usage = func() {
@@ -47,7 +46,12 @@ func main() {
 		default:
 		}
 	}
-	foundDirectories := walkDirectories2(files, 0, len(files.Directories)+1)
-	fmt.Println(foundDirectories.getDirectory(getCwd()))
+	// foundDirectories := walkDirectories2(files, 0, len(files.Directories)+1)
+	// fmt.Println(foundDirectories.getDirectory(getCwd()))
 
+	var foundDir FileList
+	walk(files, &foundDir)
+	//134/134
+	// walkDirectories2(files, 0, len(files.Directories)+1)
+	// fmt.Println(foundDir.getDirectory(getCwd()))
 }

--- a/main.go
+++ b/main.go
@@ -30,6 +30,7 @@ func main() {
 			if len(addCmd.Args()) == 1 {
 				files.addDirectory(addCmd.Args()[0], *addGit, *addDepth)
 				files.saveConfigToFile(configfile)
+				walk(files)
 				fmt.Printf("Directory %v added to search", addCmd.Args()[0])
 				os.Exit(0)
 			}
@@ -39,6 +40,7 @@ func main() {
 				if removeCmd.Args()[0] != "" {
 					files.removeDirectory(removeCmd.Args()[0])
 					files.saveConfigToFile(configfile)
+					walk(files)
 					fmt.Printf("Directory %v removed from search", removeCmd.Args()[0])
 					os.Exit(0)
 				}

--- a/main.go
+++ b/main.go
@@ -47,8 +47,7 @@ func main() {
 		}
 	}
 
-	foundDirs := walk(files)
-	var found FoundDirectories
-	found.flattenDirectories(foundDirs)
-	fmt.Println(found.getDirectory(getCwd()))
+	cache := readCacheFromFile()
+	go walk(files, cache)
+	fmt.Println(getDirectory(cache, getCwd()))
 }

--- a/main.go
+++ b/main.go
@@ -32,6 +32,7 @@ func main() {
 				files.addDirectory(addCmd.Args()[0], *addGit)
 				files.saveConfigToFile(configfile)
 				fmt.Printf("Directory %v added to search", addCmd.Args()[0])
+				os.Exit(0)
 			}
 		case "remove":
 			removeCmd.Parse(os.Args[2:])
@@ -40,6 +41,7 @@ func main() {
 					files.removeDirectory(removeCmd.Args()[0])
 					files.saveConfigToFile(configfile)
 					fmt.Printf("Directory %v removed from search", removeCmd.Args()[0])
+					os.Exit(0)
 				}
 			}
 			fmt.Println("Too many arguments")

--- a/main.go
+++ b/main.go
@@ -12,7 +12,8 @@ func main() {
 	files := readConfigFromFile(configfile)
 
 	addCmd := flag.NewFlagSet("add", flag.ExitOnError)
-	addGit := addCmd.Bool("git", false, "Should recursive search for git repo be enables")
+	addDepth := addCmd.Int("depth", 0, "Depth to search for directories")
+	addGit := addCmd.Bool("git", false, "Should recursive search for git repo be enabled")
 	removeCmd := flag.NewFlagSet("remove", flag.ExitOnError)
 	flag.Usage = func() {
 		fmt.Fprintf(os.Stderr, "\nSubcommands [add, remove]\n\n")
@@ -27,7 +28,7 @@ func main() {
 		case "add":
 			addCmd.Parse(os.Args[2:])
 			if len(addCmd.Args()) == 1 {
-				files.addDirectory(addCmd.Args()[0], *addGit)
+				files.addDirectory(addCmd.Args()[0], *addGit, *addDepth)
 				files.saveConfigToFile(configfile)
 				fmt.Printf("Directory %v added to search", addCmd.Args()[0])
 				os.Exit(0)
@@ -48,6 +49,6 @@ func main() {
 	}
 
 	cache := readCacheFromFile()
-	go walk(files, cache)
+	go walk(files)
 	fmt.Println(getDirectory(cache, getCwd()))
 }

--- a/main.go
+++ b/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"flag"
 	"fmt"
+	"os"
 )
 
 func main() {
@@ -11,22 +12,41 @@ func main() {
 
 	files := readConfigFromFile(configfile)
 
-	addPtr := flag.String("add", "", "add path to search")
-	removePtr := flag.String("remove", "", "remove path from search")
+	addCmd := flag.NewFlagSet("add", flag.ExitOnError)
+	//addFile := addCmd.String("path", "", "Full path to add")
+	addGit := addCmd.Bool("git", false, "Should recursive search for git repo be enables")
+	removeCmd := flag.NewFlagSet("remove", flag.ExitOnError)
+	flag.Usage = func() {
+		fmt.Fprintf(os.Stderr, "\nSubcommands [add, remove]\n\n")
+		fmt.Fprintf(os.Stderr, "List subcommand usage with:\n\n")
+		fmt.Fprintf(os.Stderr, "  go-quickswitch add -h\n\n")
+		fmt.Fprintf(os.Stderr, "  go-quickswitch remove -h\n\n")
+	}
 	flag.Parse()
 
-	if *addPtr != "" {
-		files.addDirectory(*addPtr)
-		files.saveConfigToFile(configfile)
-		fmt.Printf("Directory %v added to search", *addPtr)
-	} else if *removePtr != "" {
-		files.removeDirectory(*removePtr)
-		files.saveConfigToFile(configfile)
-		fmt.Printf("Directory %v removed from search", *removePtr)
-	} else {
-
-		foundDirectories := walkDirectories(&files)
-
-		fmt.Println(foundDirectories.getDirectory(getCwd()))
+	if len(os.Args) > 1 {
+		switch os.Args[1] {
+		case "add":
+			addCmd.Parse(os.Args[2:])
+			if len(addCmd.Args()) == 1 {
+				files.addDirectory(addCmd.Args()[0], *addGit)
+				files.saveConfigToFile(configfile)
+				fmt.Printf("Directory %v added to search", addCmd.Args()[0])
+			}
+		case "remove":
+			removeCmd.Parse(os.Args[2:])
+			if len(removeCmd.Args()) == 1 {
+				if removeCmd.Args()[0] != "" {
+					files.removeDirectory(removeCmd.Args()[0])
+					files.saveConfigToFile(configfile)
+					fmt.Printf("Directory %v removed from search", removeCmd.Args()[0])
+				}
+			}
+			fmt.Println("Too many arguments")
+		default:
+		}
 	}
+	foundDirectories := walkDirectories(&files)
+
+	fmt.Println(foundDirectories.getDirectory(getCwd()))
 }

--- a/main.go
+++ b/main.go
@@ -24,10 +24,9 @@ func main() {
 		files.saveConfigToFile(configfile)
 		fmt.Printf("Directory %v removed from search", *removePtr)
 	} else {
-		walkDirectories(&files)
 
-		directory := files.getDirectory(getCwd())
+		foundDirectories := walkDirectories(&files)
 
-		fmt.Println(directory)
+		fmt.Println(foundDirectories.getDirectory(getCwd()))
 	}
 }

--- a/main.go
+++ b/main.go
@@ -46,12 +46,8 @@ func main() {
 		default:
 		}
 	}
-	// foundDirectories := walkDirectories2(files, 0, len(files.Directories)+1)
-	// fmt.Println(foundDirectories.getDirectory(getCwd()))
 
 	var foundDir FileList
 	walk(files, &foundDir)
-	//134/134
-	// walkDirectories2(files, 0, len(files.Directories)+1)
-	// fmt.Println(foundDir.getDirectory(getCwd()))
+	fmt.Println(foundDir.getDirectory(getCwd()))
 }

--- a/main.go
+++ b/main.go
@@ -7,7 +7,6 @@ import (
 )
 
 func main() {
-
 	configfile := getConfigFile("quickswitch/quickswitch.json")
 
 	files := readConfigFromFile(configfile)
@@ -48,7 +47,7 @@ func main() {
 		default:
 		}
 	}
-	foundDirectories := walkDirectories(&files)
-
+	foundDirectories := walkDirectories2(files, 0, len(files.Directories)+1)
 	fmt.Println(foundDirectories.getDirectory(getCwd()))
+
 }


### PR DESCRIPTION
This adds support to traverse git directories automatically. So adding a directory containing multiple git directories or even levels of git directories will automatically add all of them.

To indicate if a directory contains git directories an additional flag is added to the add command. If the flag is not set the directory will be walked for a certain depth listing all directories found. The depth can be configured with the -depth flag. Defaults to 0 (only the directory itself will be listed). 

A very rudimentary file cache has also been implemented. When running the command without flags the list is actually loaded from this cache. In the background a refresh is happening and the next run will contain fresh results. This was to prevent sluggish feeling when the program searches deep directory trees.

Closes: #9