### PR TITLE
bugfix: continue walking if non git repository but files exist

### DIFF
--- a/internal/quickswitch/helpers.go
+++ b/internal/quickswitch/helpers.go
@@ -76,11 +76,7 @@ func walkGitDir(p string, d directories, f *map[string]time.Time, depth int) dir
 		return d
 	}
 	for _, v := range names {
-		info, err := os.Stat(p + "/" + v)
-		if err != nil {
-			return d
-		}
-		if v == ".git" || !info.IsDir() {
+		if v == ".git" {
 			d.searched = true
 			d.time = time.Now()
 			(*f)[p] = time.Now()
@@ -88,12 +84,17 @@ func walkGitDir(p string, d directories, f *map[string]time.Time, depth int) dir
 		}
 	}
 	for _, v := range names {
+		info, err := os.Stat(p + "/" + v)
+		if err != nil {
+			return d
+		}
+		if !info.IsDir() {
+			continue
+		}
 		childPath := p + "/" + v
 
 		var newChild directories
-
 		childdir = append(childdir, walkGitDir(childPath, newChild, f, d.depth+1))
-
 	}
 
 	d.child = childdir

--- a/internal/quickswitch/main.go
+++ b/internal/quickswitch/main.go
@@ -3,9 +3,8 @@ package quickswitch
 import (
 	"fmt"
 
-	"github.com/alecthomas/kong"
-
 	"github.com/HellstromIT/go-quickswitch/cmd/go-quickswitch/internal/fuzzy"
+	"github.com/alecthomas/kong"
 )
 
 type context struct {


### PR DESCRIPTION
If a directory that doesn't contain a .git folder but contains files is found the walk stops. During git walks we want to ignore those files and continue searching. This fixes that logic.