### PR TITLE
refactor: modernize Go code and fix potential issues

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,22 @@
 module github.com/HellstromIT/go-quickswitch/cmd/go-quickswitch
 
-go 1.15
+go 1.21
 
 require (
 	github.com/alecthomas/kong v0.8.0
 	github.com/ktr0731/go-fuzzyfinder v0.8.0
+)
+
+require (
+	github.com/gdamore/encoding v1.0.0 // indirect
+	github.com/gdamore/tcell/v2 v2.6.0 // indirect
+	github.com/ktr0731/go-ansisgr v0.1.0 // indirect
+	github.com/lucasb-eyer/go-colorful v1.2.0 // indirect
+	github.com/mattn/go-runewidth v0.0.15 // indirect
+	github.com/nsf/termbox-go v1.1.1 // indirect
+	github.com/pkg/errors v0.9.1 // indirect
+	github.com/rivo/uniseg v0.4.3 // indirect
+	golang.org/x/sys v0.5.0 // indirect
+	golang.org/x/term v0.5.0 // indirect
+	golang.org/x/text v0.7.0 // indirect
 )

--- a/internal/quickswitch/config.go
+++ b/internal/quickswitch/config.go
@@ -4,7 +4,6 @@ import (
 	"encoding/gob"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"time"
@@ -80,14 +79,14 @@ func (f *fileList) saveConfigToFile(filename string) error {
 		printErr(err)
 		os.Exit(1)
 	}
-	return ioutil.WriteFile(filename, bs, 0644)
+	return os.WriteFile(filename, bs, 0644)
 }
 
 func readConfigFromFile(filename string) fileList {
 	var fileList fileList
 
 	if _, err := os.Stat(filename); err == nil {
-		bs, err := ioutil.ReadFile(filename)
+		bs, err := os.ReadFile(filename)
 		if err != nil {
 			printErr(err)
 			os.Exit(1)

--- a/internal/quickswitch/helpers.go
+++ b/internal/quickswitch/helpers.go
@@ -3,6 +3,7 @@ package quickswitch
 import (
 	"fmt"
 	"os"
+	"path/filepath"
 	"time"
 )
 
@@ -40,12 +41,12 @@ func walkDir(p string, d directories, f *map[string]time.Time, depth int, maxDep
 			return d
 		}
 		for _, v := range names {
-			info, err := os.Stat(p + "/" + v)
+			info, err := os.Stat(filepath.Join(p, v))
 			if err != nil {
 				return d
 			}
 			if info.IsDir() {
-				childPath := p + "/" + v
+				childPath := filepath.Join(p, v)
 
 				var newChild directories
 
@@ -84,14 +85,14 @@ func walkGitDir(p string, d directories, f *map[string]time.Time, depth int) dir
 		}
 	}
 	for _, v := range names {
-		info, err := os.Stat(p + "/" + v)
+		info, err := os.Stat(filepath.Join(p, v))
 		if err != nil {
 			return d
 		}
 		if !info.IsDir() {
 			continue
 		}
-		childPath := p + "/" + v
+		childPath := filepath.Join(p, v)
 
 		var newChild directories
 		childdir = append(childdir, walkGitDir(childPath, newChild, f, d.depth+1))

--- a/internal/quickswitch/main.go
+++ b/internal/quickswitch/main.go
@@ -2,6 +2,7 @@ package quickswitch
 
 import (
 	"fmt"
+	"sync"
 
 	"github.com/HellstromIT/go-quickswitch/cmd/go-quickswitch/internal/fuzzy"
 	"github.com/alecthomas/kong"
@@ -63,8 +64,14 @@ func (v *versionCmd) Run(ctx *context) error {
 
 func (r *runCmd) Run(ctx *context) error {
 	cache := readCacheFromFile()
-	go walk(ctx.files)
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		walk(ctx.files)
+	}()
 	fmt.Println(fuzzy.GetDirectory(cache, getCwd()))
+	wg.Wait()
 	return nil
 }
 


### PR DESCRIPTION
- Update Go version from 1.15 to 1.21
- Replace deprecated ioutil.WriteFile/ReadFile with os.WriteFile/ReadFile
- Use filepath.Join instead of string concatenation for cross-platform path handling
- Fix race condition in run command by waiting for cache update goroutine to complete