### PR TITLE
feat: add hot reload support to fuzzy finder

### DIFF
--- a/internal/fuzzy/main.go
+++ b/internal/fuzzy/main.go
@@ -1,23 +1,24 @@
 package fuzzy
 
 import (
-	"time"
+	"sync"
 
 	"github.com/ktr0731/go-fuzzyfinder"
 )
 
-// GetDirectory Spawn a fuzzy finder prompt
-func GetDirectory(m map[string]time.Time, cwd string) string {
-	var list []string
-
-	for i := range m {
-		list = append(list, i)
-	}
-	idx, err := fuzzyfinder.Find(list, func(i int) string {
-		return list[i]
-	})
+// GetDirectoryLive spawns a fuzzy finder with hot reload support.
+// The list can be updated externally while the finder is running.
+// Callers must hold mu.Lock() when modifying the list.
+func GetDirectoryLive(list *[]string, mu *sync.RWMutex, cwd string) string {
+	idx, err := fuzzyfinder.Find(
+		list,
+		func(i int) string {
+			return (*list)[i]
+		},
+		fuzzyfinder.WithHotReloadLock(mu.RLocker()),
+	)
 	if err != nil {
 		return cwd
 	}
-	return list[idx]
+	return (*list)[idx]
 }

--- a/internal/quickswitch/config_test.go
+++ b/internal/quickswitch/config_test.go
@@ -7,46 +7,51 @@ import (
 	"testing"
 )
 
+const (
+	testPathProjects = "/home/user/projects"
+	testPathWork     = "/home/user/work"
+)
+
 func TestAddDirectory(t *testing.T) {
 	tests := []struct {
-		name          string
-		initial       []directoryConf
-		addPath       string
-		addGit        bool
-		addDepth      int
-		wantLen       int
-		wantContains  string
+		name         string
+		initial      []directoryConf
+		addPath      string
+		addGit       bool
+		addDepth     int
+		wantLen      int
+		wantContains string
 	}{
 		{
 			name:         "add to empty list",
 			initial:      []directoryConf{},
-			addPath:      "/home/user/projects",
+			addPath:      testPathProjects,
 			addGit:       true,
 			addDepth:     0,
 			wantLen:      1,
-			wantContains: "/home/user/projects",
+			wantContains: testPathProjects,
 		},
 		{
 			name: "add to existing list",
 			initial: []directoryConf{
-				{Directory: "/home/user/work", Git: false, Depth: 2},
+				{Directory: testPathWork, Git: false, Depth: 2},
 			},
-			addPath:      "/home/user/projects",
+			addPath:      testPathProjects,
 			addGit:       true,
 			addDepth:     0,
 			wantLen:      2,
-			wantContains: "/home/user/projects",
+			wantContains: testPathProjects,
 		},
 		{
 			name: "add duplicate is ignored",
 			initial: []directoryConf{
-				{Directory: "/home/user/projects", Git: true, Depth: 0},
+				{Directory: testPathProjects, Git: true, Depth: 0},
 			},
-			addPath:      "/home/user/projects",
+			addPath:      testPathProjects,
 			addGit:       false,
 			addDepth:     5,
 			wantLen:      1,
-			wantContains: "/home/user/projects",
+			wantContains: testPathProjects,
 		},
 	}
 
@@ -100,8 +105,8 @@ func TestSaveAndReadConfigFile(t *testing.T) {
 	// Create a fileList and save it
 	original := &fileList{
 		Directories: []directoryConf{
-			{Directory: "/home/user/projects", Git: true, Depth: 0},
-			{Directory: "/home/user/work", Git: false, Depth: 3},
+			{Directory: testPathProjects, Git: true, Depth: 0},
+			{Directory: testPathWork, Git: false, Depth: 3},
 		},
 	}
 
@@ -126,8 +131,8 @@ func TestSaveAndReadConfigFile(t *testing.T) {
 		t.Errorf("loaded config has %d directories, want 2", len(loaded.Directories))
 	}
 
-	if loaded.Directories[0].Directory != "/home/user/projects" {
-		t.Errorf("first directory = %s, want /home/user/projects", loaded.Directories[0].Directory)
+	if loaded.Directories[0].Directory != testPathProjects {
+		t.Errorf("first directory = %s, want %s", loaded.Directories[0].Directory, testPathProjects)
 	}
 
 	if loaded.Directories[0].Git != true {

--- a/internal/quickswitch/helpers.go
+++ b/internal/quickswitch/helpers.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"sync"
 	"time"
 )
 
@@ -136,4 +137,98 @@ func getCwd() string {
 	}
 
 	return path
+}
+
+// walkLive walks directories and updates both the cache map and a live list.
+// The list is updated with mutex protection for hot reload support.
+func walkLive(f fileList, list *[]string, mu *sync.RWMutex, seen map[string]bool) {
+	flat := make(map[string]time.Time)
+
+	for _, dir := range f.Directories {
+		if dir.Git {
+			walkGitDirLive(dir.Directory, &flat, list, mu, seen)
+		} else {
+			walkDirLive(dir.Directory, &flat, 0, dir.Depth, list, mu, seen)
+		}
+	}
+
+	saveCacheToFile(flat)
+}
+
+func walkDirLive(p string, f *map[string]time.Time, depth int, maxDepth int, list *[]string, mu *sync.RWMutex, seen map[string]bool) {
+	// Add this directory to the live list if not already seen
+	mu.Lock()
+	if !seen[p] {
+		seen[p] = true
+		*list = append(*list, p)
+	}
+	mu.Unlock()
+
+	(*f)[p] = time.Now()
+
+	if depth >= maxDepth {
+		return
+	}
+
+	file, err := os.Open(p)
+	if err != nil {
+		return
+	}
+	defer file.Close()
+
+	names, err := file.Readdirnames(0)
+	if err != nil {
+		return
+	}
+
+	for _, v := range names {
+		childPath := filepath.Join(p, v)
+		info, err := os.Stat(childPath)
+		if err != nil {
+			continue
+		}
+		if info.IsDir() {
+			walkDirLive(childPath, f, depth+1, maxDepth, list, mu, seen)
+		}
+	}
+}
+
+func walkGitDirLive(p string, f *map[string]time.Time, list *[]string, mu *sync.RWMutex, seen map[string]bool) {
+	file, err := os.Open(p)
+	if err != nil {
+		return
+	}
+	defer file.Close()
+
+	names, err := file.Readdirnames(0)
+	if err != nil {
+		return
+	}
+
+	// Check if this is a git repo
+	for _, v := range names {
+		if v == ".git" {
+			// Found a git repo - add it and stop recursing
+			mu.Lock()
+			if !seen[p] {
+				seen[p] = true
+				*list = append(*list, p)
+			}
+			mu.Unlock()
+			(*f)[p] = time.Now()
+			return
+		}
+	}
+
+	// Not a git repo, recurse into subdirectories
+	for _, v := range names {
+		childPath := filepath.Join(p, v)
+		info, err := os.Stat(childPath)
+		if err != nil {
+			continue
+		}
+		if info.IsDir() {
+			walkGitDirLive(childPath, f, list, mu, seen)
+		}
+	}
 }

--- a/internal/quickswitch/helpers_test.go
+++ b/internal/quickswitch/helpers_test.go
@@ -3,9 +3,18 @@ package quickswitch
 import (
 	"os"
 	"path/filepath"
+	"sync"
 	"testing"
 	"time"
 )
+
+// mustMkdirAll creates a directory and fails the test if it errors
+func mustMkdirAll(t *testing.T, path string) {
+	t.Helper()
+	if err := os.MkdirAll(path, 0755); err != nil {
+		t.Fatalf("failed to create test directory %s: %v", path, err)
+	}
+}
 
 func TestFindInSlice(t *testing.T) {
 	tests := []struct {
@@ -76,17 +85,17 @@ func TestFindInDirectoryConf(t *testing.T) {
 		{
 			name: "find existing directory",
 			slice: []directoryConf{
-				{Directory: "/home/user/projects", Git: true, Depth: 0},
-				{Directory: "/home/user/work", Git: false, Depth: 2},
+				{Directory: testPathProjects, Git: true, Depth: 0},
+				{Directory: testPathWork, Git: false, Depth: 2},
 			},
-			val:       "/home/user/work",
+			val:       testPathWork,
 			wantIndex: 1,
 			wantFound: true,
 		},
 		{
 			name: "directory not found",
 			slice: []directoryConf{
-				{Directory: "/home/user/projects", Git: true, Depth: 0},
+				{Directory: testPathProjects, Git: true, Depth: 0},
 			},
 			val:       "/home/user/other",
 			wantIndex: -1,
@@ -95,7 +104,7 @@ func TestFindInDirectoryConf(t *testing.T) {
 		{
 			name:      "empty slice",
 			slice:     []directoryConf{},
-			val:       "/home/user/projects",
+			val:       testPathProjects,
 			wantIndex: -1,
 			wantFound: false,
 		},
@@ -120,9 +129,7 @@ func TestWalkDir(t *testing.T) {
 
 	// Create: tmpDir/a/b/c
 	nestedDir := filepath.Join(tmpDir, "a", "b", "c")
-	if err := os.MkdirAll(nestedDir, 0755); err != nil {
-		t.Fatalf("failed to create test directories: %v", err)
-	}
+	mustMkdirAll(t, nestedDir)
 
 	// Create a file to ensure it's not included
 	testFile := filepath.Join(tmpDir, "a", "test.txt")
@@ -182,20 +189,14 @@ func TestWalkGitDir(t *testing.T) {
 
 	// Create: tmpDir/repo1/.git (git repo)
 	repo1 := filepath.Join(tmpDir, "repo1")
-	if err := os.MkdirAll(filepath.Join(repo1, ".git"), 0755); err != nil {
-		t.Fatalf("failed to create test directories: %v", err)
-	}
+	mustMkdirAll(t, filepath.Join(repo1, ".git"))
 
 	// Create: tmpDir/repo1/subdir (should not be included, parent is git repo)
-	if err := os.MkdirAll(filepath.Join(repo1, "subdir"), 0755); err != nil {
-		t.Fatalf("failed to create test directories: %v", err)
-	}
+	mustMkdirAll(t, filepath.Join(repo1, "subdir"))
 
 	// Create: tmpDir/notrepo/nested/repo2/.git
 	repo2 := filepath.Join(tmpDir, "notrepo", "nested", "repo2")
-	if err := os.MkdirAll(filepath.Join(repo2, ".git"), 0755); err != nil {
-		t.Fatalf("failed to create test directories: %v", err)
-	}
+	mustMkdirAll(t, filepath.Join(repo2, ".git"))
 
 	flat := make(map[string]time.Time)
 	var d directories
@@ -213,5 +214,94 @@ func TestWalkGitDir(t *testing.T) {
 	subdir := filepath.Join(repo1, "subdir")
 	if _, ok := flat[subdir]; ok {
 		t.Errorf("walkGitDir() should not include subdirs of git repos: %s", subdir)
+	}
+}
+
+func TestWalkDirLive(t *testing.T) {
+	// Create a temporary directory structure
+	tmpDir := t.TempDir()
+
+	// Create: tmpDir/a/b
+	nestedDir := filepath.Join(tmpDir, "a", "b")
+	mustMkdirAll(t, nestedDir)
+
+	var list []string
+	var mu sync.RWMutex
+	seen := make(map[string]bool)
+	flat := make(map[string]time.Time)
+
+	walkDirLive(tmpDir, &flat, 0, 2, &list, &mu, seen)
+
+	// Should find tmpDir, tmpDir/a, tmpDir/a/b
+	expectedDirs := []string{tmpDir, filepath.Join(tmpDir, "a"), filepath.Join(tmpDir, "a", "b")}
+
+	if len(list) != len(expectedDirs) {
+		t.Errorf("walkDirLive() found %d directories, want %d", len(list), len(expectedDirs))
+	}
+
+	for _, dir := range expectedDirs {
+		if !seen[dir] {
+			t.Errorf("walkDirLive() missing expected directory: %s", dir)
+		}
+	}
+
+	// Verify cache map is also populated
+	for _, dir := range expectedDirs {
+		if _, ok := flat[dir]; !ok {
+			t.Errorf("walkDirLive() cache missing expected directory: %s", dir)
+		}
+	}
+}
+
+func TestWalkGitDirLive(t *testing.T) {
+	// Create a temporary directory structure with .git folders
+	tmpDir := t.TempDir()
+
+	// Create: tmpDir/repo1/.git
+	repo1 := filepath.Join(tmpDir, "repo1")
+	mustMkdirAll(t, filepath.Join(repo1, ".git"))
+
+	// Create: tmpDir/notrepo/repo2/.git
+	repo2 := filepath.Join(tmpDir, "notrepo", "repo2")
+	mustMkdirAll(t, filepath.Join(repo2, ".git"))
+
+	var list []string
+	var mu sync.RWMutex
+	seen := make(map[string]bool)
+	flat := make(map[string]time.Time)
+
+	walkGitDirLive(tmpDir, &flat, &list, &mu, seen)
+
+	// Should find repo1 and repo2
+	expectedRepos := []string{repo1, repo2}
+
+	if len(list) != len(expectedRepos) {
+		t.Errorf("walkGitDirLive() found %d repos, want %d", len(list), len(expectedRepos))
+	}
+
+	for _, repo := range expectedRepos {
+		if !seen[repo] {
+			t.Errorf("walkGitDirLive() missing expected repo: %s", repo)
+		}
+	}
+}
+
+func TestWalkLiveSkipsDuplicates(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	var list []string
+	var mu sync.RWMutex
+	seen := make(map[string]bool)
+	flat := make(map[string]time.Time)
+
+	// Pre-populate seen with tmpDir
+	seen[tmpDir] = true
+	list = append(list, tmpDir)
+
+	walkDirLive(tmpDir, &flat, 0, 0, &list, &mu, seen)
+
+	// Should not add tmpDir again
+	if len(list) != 1 {
+		t.Errorf("walkDirLive() should not add duplicates, got %d items", len(list))
 	}
 }

--- a/internal/quickswitch/main.go
+++ b/internal/quickswitch/main.go
@@ -64,13 +64,27 @@ func (v *versionCmd) Run(ctx *context) error {
 
 func (r *runCmd) Run(ctx *context) error {
 	cache := readCacheFromFile()
+
+	// Initialize list from cache
+	var list []string
+	seen := make(map[string]bool)
+	for path := range cache {
+		list = append(list, path)
+		seen[path] = true
+	}
+
+	var mu sync.RWMutex
 	var wg sync.WaitGroup
+
+	// Start walking directories in background with hot reload
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
-		walk(ctx.files)
+		walkLive(ctx.files, &list, &mu, seen)
 	}()
-	fmt.Println(fuzzy.GetDirectory(cache, getCwd()))
+
+	// Show fuzzy finder with hot reload support
+	fmt.Println(fuzzy.GetDirectoryLive(&list, &mu, getCwd()))
 	wg.Wait()
 	return nil
 }


### PR DESCRIPTION
The fuzzy finder now updates in real-time as new directories are discovered during the background walk, improving responsiveness when searching large directory trees.

Changes:
- Add GetDirectoryLive() with WithHotReloadLock() support
- Add walkLive(), walkDirLive(), walkGitDirLive() for concurrent updates
- Remove unused GetDirectory() function
- Refactor tests to use constants and mustMkdirAll helper