### PR TITLE
ci: build windows/arm64 instead of windows/arm

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -53,7 +53,7 @@ jobs:
     strategy:
       matrix:
         goos: [windows]
-        goarch: ["386", amd64, arm]
+        goarch: ["386", amd64, arm64]
     steps:
     - uses: actions/checkout@v2
     - name: Set APP_VERSION env


### PR DESCRIPTION
## Problem

The `v0.3.3` release workflow failed on the Windows ARM job:

```
go: unsupported GOOS/GOARCH pair windows/arm
```

The 32-bit `windows/arm` port is no longer supported by the Go toolchain (the workflow pins `goversion: "1.26"`). With `fail-fast` enabled, this also cancelled the otherwise-healthy `windows/386` and `windows/amd64` jobs.

## Fix

Windows-on-ARM is `arm64`-only. Swap `arm` → `arm64` in the Windows matrix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)