### PR TITLE
ci: bump actions/checkout from v2 to v4

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -13,7 +13,7 @@ jobs:
         goos: [linux]
         goarch: ["386", amd64, arm64, arm]
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Set APP_VERSION env
       run: echo APP_VERSION=$(echo ${GITHUB_REF} | rev | cut -d'/' -f 1 | rev ) >> ${GITHUB_ENV}
     - uses: wangyoucao577/go-release-action@master
@@ -34,7 +34,7 @@ jobs:
         goos: [darwin]
         goarch: [amd64]
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Set APP_VERSION env
       run: echo APP_VERSION=$(echo ${GITHUB_REF} | rev | cut -d'/' -f 1 | rev ) >> ${GITHUB_ENV}
     - uses: wangyoucao577/go-release-action@master
@@ -55,7 +55,7 @@ jobs:
         goos: [windows]
         goarch: ["386", amd64, arm64]
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Set APP_VERSION env
       run: echo APP_VERSION=$(echo ${GITHUB_REF} | rev | cut -d'/' -f 1 | rev ) >> ${GITHUB_ENV}
     - uses: wangyoucao577/go-release-action@master


### PR DESCRIPTION
## Problem

The `v0.3.3` release run flagged a deprecation warning:

> Node.js 20 actions are deprecated. `actions/checkout@v2` is running on Node.js 20.

GitHub is forcing Node 20 actions onto Node 24 on **2026-06-02** and removing Node 20 from runners on **2026-09-16**.

## Fix

Bump all three `actions/checkout@v2` references in `release.yaml` to `@v4` (runs on Node 24).

🤖 Generated with [Claude Code](https://claude.com/claude-code)