### PR TITLE
fix: stop crawler following symlinks and don't block run on the crawl

### DIFF
--- a/internal/quickswitch/config.go
+++ b/internal/quickswitch/config.go
@@ -147,16 +147,27 @@ func readConfigFromFile(filename string) (ConfigResult, error) {
 	return result, fmt.Errorf("failed to stat config file: %w", err)
 }
 
+// saveCacheToFile writes the cache atomically: it encodes to a temp file in
+// the same directory and renames it into place. This way a process exiting
+// mid-write (the background crawl is no longer waited on) can never leave a
+// truncated cache file behind.
 func saveCacheToFile(cachePath string, m map[string]time.Time) error {
-	file, err := os.Create(cachePath)
+	tmp, err := os.CreateTemp(filepath.Dir(cachePath), "cache-*.tmp")
 	if err != nil {
-		return fmt.Errorf("failed to create cache file: %w", err)
+		return fmt.Errorf("failed to create cache temp file: %w", err)
 	}
-	defer file.Close()
+	tmpName := tmp.Name()
+	defer os.Remove(tmpName) // no-op once the rename below succeeds
 
-	e := gob.NewEncoder(file)
-	if err := e.Encode(m); err != nil {
+	if err := gob.NewEncoder(tmp).Encode(m); err != nil {
+		tmp.Close()
 		return fmt.Errorf("failed to encode cache: %w", err)
+	}
+	if err := tmp.Close(); err != nil {
+		return fmt.Errorf("failed to close cache temp file: %w", err)
+	}
+	if err := os.Rename(tmpName, cachePath); err != nil {
+		return fmt.Errorf("failed to replace cache file: %w", err)
 	}
 	log.Debug("saved cache to file", "path", cachePath, "entries", len(m))
 	return nil

--- a/internal/quickswitch/helpers.go
+++ b/internal/quickswitch/helpers.go
@@ -52,7 +52,9 @@ func walkDir(p string, d directories, f *map[string]time.Time, depth int, maxDep
 			return d
 		}
 		for _, v := range names {
-			info, err := os.Stat(filepath.Join(p, v))
+			// Lstat, not Stat: do not follow symlinks. A symlinked
+			// directory (e.g. a Nix "result" link) must not be crawled.
+			info, err := os.Lstat(filepath.Join(p, v))
 			if err != nil {
 				return d
 			}
@@ -108,7 +110,9 @@ func walkGitDir(p string, d directories, f *map[string]time.Time, depth, maxDept
 				continue
 			}
 			childPath := filepath.Join(p, v)
-			info, err := os.Stat(childPath)
+			// Lstat, not Stat: do not follow symlinks. A symlinked
+			// directory (e.g. a Nix "result" link) must not be crawled.
+			info, err := os.Lstat(childPath)
 			if err != nil {
 				continue
 			}
@@ -205,7 +209,9 @@ func walkDirLive(p string, f *map[string]time.Time, depth int, maxDepth int, lis
 
 	for _, v := range names {
 		childPath := filepath.Join(p, v)
-		info, err := os.Stat(childPath)
+		// Lstat, not Stat: do not follow symlinks. A symlinked
+		// directory (e.g. a Nix "result" link) must not be crawled.
+		info, err := os.Lstat(childPath)
 		if err != nil {
 			continue
 		}
@@ -253,7 +259,9 @@ func walkGitDirLive(p string, f *map[string]time.Time, depth, maxDepth int, list
 			continue
 		}
 		childPath := filepath.Join(p, v)
-		info, err := os.Stat(childPath)
+		// Lstat, not Stat: do not follow symlinks. A symlinked
+		// directory (e.g. a Nix "result" link) must not be crawled.
+		info, err := os.Lstat(childPath)
 		if err != nil {
 			continue
 		}

--- a/internal/quickswitch/helpers_test.go
+++ b/internal/quickswitch/helpers_test.go
@@ -343,6 +343,54 @@ func TestWalkGitDirLiveDepthLimit(t *testing.T) {
 	}
 }
 
+func TestWalkGitDirDoesNotFollowSymlinks(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	// A real repo the crawler must not reach by following a symlink.
+	target := filepath.Join(tmpDir, "target")
+	mustMkdirAll(t, filepath.Join(target, "repo", ".git"))
+
+	// A non-git directory containing a symlink to the tree above, mimicking
+	// a Nix "result" link that points into the store.
+	project := filepath.Join(tmpDir, "project")
+	mustMkdirAll(t, project)
+	if err := os.Symlink(target, filepath.Join(project, "result")); err != nil {
+		t.Fatalf("failed to create symlink: %v", err)
+	}
+
+	flat := make(map[string]time.Time)
+	var d directories
+	walkGitDir(project, d, &flat, 0, 0)
+
+	if len(flat) != 0 {
+		t.Errorf("walkGitDir() followed a symlink, cached %d entries: %v", len(flat), flat)
+	}
+}
+
+func TestWalkGitDirLiveDoesNotFollowSymlinks(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	target := filepath.Join(tmpDir, "target")
+	mustMkdirAll(t, filepath.Join(target, "repo", ".git"))
+
+	project := filepath.Join(tmpDir, "project")
+	mustMkdirAll(t, project)
+	if err := os.Symlink(target, filepath.Join(project, "result")); err != nil {
+		t.Fatalf("failed to create symlink: %v", err)
+	}
+
+	var list []string
+	var mu sync.RWMutex
+	seen := make(map[string]bool)
+	flat := make(map[string]time.Time)
+
+	walkGitDirLive(project, &flat, 0, 0, &list, &mu, seen)
+
+	if len(list) != 0 {
+		t.Errorf("walkGitDirLive() followed a symlink, found %d entries: %v", len(list), list)
+	}
+}
+
 func TestWalkLiveSkipsDuplicates(t *testing.T) {
 	tmpDir := t.TempDir()
 

--- a/internal/quickswitch/main.go
+++ b/internal/quickswitch/main.go
@@ -90,18 +90,17 @@ func (r *runCmd) Run(ctx *context) error {
 	}
 
 	var mu sync.RWMutex
-	var wg sync.WaitGroup
 
-	// Start walking directories in background with hot reload
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
-		walkLive(ctx.files, &list, &mu, seen, ctx.cacheFile)
-	}()
+	// Crawl directories in the background so the fuzzy finder hot-reloads as
+	// repositories are discovered. We deliberately do not wait for the crawl
+	// to finish: once the user picks an entry the command returns
+	// immediately. The crawl persists its results to the cache as it goes
+	// (see saveCacheToFile), so an unfinished crawl simply leaves the cache
+	// as it was rather than blocking the user.
+	go walkLive(ctx.files, &list, &mu, seen, ctx.cacheFile)
 
 	// Show fuzzy finder with hot reload support
 	fmt.Println(fuzzy.GetDirectoryLive(&list, &mu, getCwd()))
-	wg.Wait()
 	return nil
 }
 


### PR DESCRIPTION
## Problem

Running `go-quickswitch` and selecting/exiting hung for ~30s before the command returned.

Two causes:

1. **`runCmd.Run` blocked on the background crawl.** After the fuzzy finder returned, `wg.Wait()` held the command until the background `walkLive` crawl finished — so the user waited for the whole crawl.

2. **The crawler followed symlinks.** It used `os.Stat`, which resolves symlinks. A non-git directory containing a symlink into a large tree — a Nix `result` link, or `.devenv/profile` pointing into `/nix/store` — was crawled in full (observed: ~1.1M directories, a 212 MB cache, a 44s crawl).

## Changes

- `walkDir`, `walkGitDir`, `walkDirLive`, `walkGitDirLive`: use `os.Lstat` instead of `os.Stat` so symlinked directories are not descended into.
- `runCmd.Run`: drop `wg.Wait()` — once the user picks an entry the command returns immediately. The background crawl still persists to the cache as it goes.
- `saveCacheToFile`: write atomically (temp file + rename) so a process exiting mid-write cannot leave a truncated cache.
- Tests: added `TestWalkGitDirDoesNotFollowSymlinks` and `TestWalkGitDirLiveDoesNotFollowSymlinks`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)